### PR TITLE
Add with-refresh form action wrapper that refreshes the page after form submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Initialize Storage on Vercel with this schema:
+```
+CREATE TABLE backronyms ( backronym varchar(255), votes integer NOT NULL DEFAULT 0);
+```

--- a/src/app/components/submit-to-leaderboard.tsx
+++ b/src/app/components/submit-to-leaderboard.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {submitForVoting} from '../form-handlers/submit-to-leaderboard';
+import { withRefresh } from '../form-handlers/with-refresh';
 
 //Client component using a server action https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions
 export default function SubmitToLeaderBoard(props: {
@@ -9,23 +10,19 @@ export default function SubmitToLeaderBoard(props: {
   f_word2: string,
   w_word: string,
   confirmation_hash: string}) {
-  const [clicked, setClicked] = useState(false);
   const router = useRouter();
 
   return (
-    <form className="submit" action={submitForVoting} onSubmit={() => setClicked(true)}>
+    <form className="submit" action={withRefresh(submitForVoting)}>
       <input type="hidden" name="confirmation_hash" value={props.confirmation_hash} />
       <input type="hidden" name="f_word1" value={props.f_word1} />
       <input type="hidden" name="f_word2" value={props.f_word2} />
       <input type="hidden" name="w_word" value={props.w_word} />
-      {clicked ?
-        <p>Submitted, reload to vote</p> :
-        <div className='buttons'>
-          <button type="reset" onClick={() => router.refresh()}>Give Me Another!</button>
-          <div className='or'>OR</div>
-          <button type="submit">Submit to Leaderboard</button>
-        </div>
-      }
+      <div className='buttons'>
+        <button type="reset" onClick={() => router.refresh()}>Give Me Another!</button>
+        <div className='or'>OR</div>
+        <button type="submit">Submit to Leaderboard</button>
+      </div>
     </form>
   )
 }

--- a/src/app/components/vote-for-me.tsx
+++ b/src/app/components/vote-for-me.tsx
@@ -1,21 +1,14 @@
 'use client'
-import { useState } from "react"
-import { useRouter } from 'next/navigation';
 import VoteForMeHandler from "../form-handlers/vote-for-me"
+import { withRefresh } from "../form-handlers/with-refresh";
 
 export default function VoteForMe(props: {candidate: string}) {
-  const [clicked, setClicked] = useState(false)
-  const router = useRouter();
-
   return (
     <>
-    {clicked ?
-      <span className="voted">vote recorded</span> :
-      <form action={VoteForMeHandler} onSubmit={() => setClicked(true)}>
+      <form action={withRefresh(VoteForMeHandler)}>
         <input type="hidden" name="candidate" value={props.candidate}/>
         <button type="submit">Vote For Me!</button>
       </form>
-    }
     </>
   )
 }

--- a/src/app/form-handlers/submit-to-leaderboard.tsx
+++ b/src/app/form-handlers/submit-to-leaderboard.tsx
@@ -20,7 +20,7 @@ export async function submitForVoting(formData: FormData) {
   else {
     //Insert the data into the database
     const backronym = `${f_word1} ${f_word2} ${w_word}`;
-    const { rows } = await sql`INSERT INTO backronyms VALUES (${backronym}, 1)`
+    const { rows } = await sql`INSERT INTO backronyms VALUES (${backronym}, 0)`
     console.log(rows);
   }
 }

--- a/src/app/form-handlers/with-refresh.ts
+++ b/src/app/form-handlers/with-refresh.ts
@@ -1,0 +1,9 @@
+import { useRouter } from "next/navigation";
+
+export function withRefresh(action: any) {
+  const router = useRouter();
+  return async (formData: FormData) => {
+    await action(formData);
+    router.refresh();
+  };
+}


### PR DESCRIPTION
Add with-refresh form action wrapper that refreshes the page after form actions wrapped in it

The idea behind this technique is hinted by the fact that you can pass actions as props to client components and wrap them in client actions:
https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions#props

This might at first glance seem like equivalent to adding an onClick handler to form and calling router.refresh() except for the fact that onClick I think will run on hydration of the app and will likely have to wait for other hydration. Instead, client functions in actions are "Progressively enhanced" and prioritized for hydration

Overall, an action is just a function, it doesn't have to be pure server or pure client, one can wrap another. =)

Here is Andrew Clark talking about that: https://twitter.com/acdlite/status/1654159620712067072

